### PR TITLE
Deployment to heroku was failing with last merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ deploy:
   app: qc-engine
   on:
     repo: Quick-Command/qc-engine
-    branch: main 
+    branch: main
     run: rails db:migrate
+    skip_cleanup: 'true'


### PR DESCRIPTION
Adding skip_cleanup to travis.yml file for fix

Co-authored-by: Jeremiah Michlitsch <61896482+jmichlitsch@users.noreply.github.com>

### What Changed?
- The deployment to Heroku failed on Travis CI. There were a few articles that noted to include `skip_cleanup :true`
### What's Next?
- Make sure that it is deploying correctly after fix
### Known Issues?
- Hekou deployment
### Test Coverage?
- N/A
### README & Documentation
- N/A
